### PR TITLE
Add initial changes for storing JWT access token in cookies instead.

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -4,7 +4,7 @@ import Boom from '@hapi/boom';
 import {User} from '../models/users';
 import {generateToken} from '../utilities/auth';
 
-export async function login(request, h) {
+export const login = async (request, h) => {
   const {username, password} = request.payload;
   const user = await User.findOne({username});
 
@@ -18,10 +18,20 @@ export async function login(request, h) {
 
   const token = generateToken(user);
 
+  h.state('accessToken', token);
   return h.response({token});
-}
+};
 
-export async function signup(request, h) {
+export const logout = async (request, h) => {
+  try {
+    h.unstate('accessToken');
+    return h.response().code(200);
+  } catch (error) {
+    return Boom.badRequest('Logout failed');
+  }
+};
+
+export const signup = async (request, h) => {
   const {username, password, displayName} = request.payload;
 
   try {
@@ -39,4 +49,11 @@ export async function signup(request, h) {
   return h.response({
     message: 'Sign-up was successful.',
   });
-}
+};
+
+export const isLoggedIn = async (request, h) => {
+  const {username} = request.pre.credentials;
+  const response = {username};
+
+  return h.response(response).code(200);
+};

--- a/src/controllers/tweets.js
+++ b/src/controllers/tweets.js
@@ -3,13 +3,13 @@ import Boom from '@hapi/boom';
 import {Tweet} from '../models/tweets';
 import {User} from '../models/users';
 
-export async function getTweets(request, h) {
+export const getTweets = async (request, h) => {
   const tweets = await Tweet.find({});
   return h.response(tweets).code(200);
-}
+};
 
-export async function createTweet(request, h) {
-  const {username} = request.auth.credentials;
+export const createTweet = async (request, h) => {
+  const {username} = request.pre.credentials;
   const {timeElapsed, content} = request.payload;
   const {displayName} = await User.findOne({username});
 
@@ -21,9 +21,9 @@ export async function createTweet(request, h) {
   });
 
   return h.response(tweet);
-}
+};
 
-export async function getTweetById(request, h) {
+export const getTweetById = async (request, h) => {
   const {id} = request.params;
   const tweet = await Tweet.findById(id).exec();
 
@@ -33,9 +33,9 @@ export async function getTweetById(request, h) {
   }
 
   return Boom.notFound('No tweet found');
-}
+};
 
-export async function deleteTweet(request, h) {
+export const deleteTweet = async (request, h) => {
   const {id} = request.params;
   const tweet = await Tweet.findByIdAndRemove(id);
 
@@ -44,4 +44,4 @@ export async function deleteTweet(request, h) {
   }
 
   return Boom.notFound('Cannot delete a non-existing tweet');
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -20,32 +20,21 @@ const init = async () => {
       },
       cors: {
         origin: ['*'],
+        credentials: true,
       },
     },
   });
 
   await server.register(Jwt);
 
-  server.auth.strategy('jwt', 'jwt', {
-    keys: 'some_shared_secret',
-    verify: {
-      aud: 'urn:audience:test',
-      iss: 'urn:issuer:test',
-      sub: false,
-      nbf: true,
-      exp: true,
-      maxAgeSec: 14400,
-      timeSkewSec: 15,
-    },
-    validate: (artifacts, request, h) => {
-      return {
-        isValid: true,
-        credentials: {username: artifacts.decoded.payload.username},
-      };
-    },
+  server.state('accessToken', {
+    ttl: null,
+    isSecure: false,
+    isHttpOnly: true,
+    encoding: 'base64json',
+    clearInvalid: true,
+    strictHeader: true,
   });
-
-  server.auth.default('jwt');
 
   server.route(routes);
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,7 +1,10 @@
-import {login, signup} from '../controllers/auth';
+import {login, logout, signup, isLoggedIn} from '../controllers/auth';
+import {jwtPreHandler} from '../utilities/auth';
 
 const options = {
-  auth: false,
+  pre: [
+    jwtPreHandler,
+  ],
 };
 
 const routes = [
@@ -9,12 +12,22 @@ const routes = [
     method: 'POST',
     path: '/login',
     handler: login,
+  },
+  {
+    method: 'POST',
+    path: '/logout',
+    handler: logout,
     options,
   },
   {
     method: 'POST',
     path: '/signup',
     handler: signup,
+  },
+  {
+    method: 'GET',
+    path: '/isLoggedIn',
+    handler: isLoggedIn,
     options,
   },
 ];

--- a/src/routes/tweets.js
+++ b/src/routes/tweets.js
@@ -2,18 +2,27 @@ import Joi from 'joi';
 import {
   getTweets, createTweet, getTweetById, deleteTweet,
 } from '../controllers/tweets';
+import {jwtPreHandler} from '../utilities/auth';
+
+const options = {
+  pre: [
+    jwtPreHandler,
+  ],
+};
 
 const routes = [
   {
     method: 'GET',
     path: '/tweets',
     handler: getTweets,
+    options,
   },
   {
     method: 'POST',
     path: '/tweets',
     handler: createTweet,
     options: {
+      ...options,
       validate: {
         payload: Joi.object({
           timeElapsed: Joi.string().required(),


### PR DESCRIPTION
- Note that the front-end apps using this service need adjustment.
- It's really a bad practice to store your access token in localSorage.
- Add an endppoint for logout. Upon successful logout, it should clear the cookie
  for the access token.
- Add an endpoint for verifying if the user is logged in.